### PR TITLE
SERVER-83258 support lockfile 2.0 and platform markers.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -115,3 +115,28 @@ container_pull(
     repository = "library/python",
     tag = "3.7.4-slim-buster",
 )
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "platforms",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+    ],
+    sha256 = "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,8 +25,6 @@ load("@com_sonia_rules_poetry//rules_poetry:defs.bzl", "poetry_deps")
 
 poetry_deps()
 
-
-
 # Go rules to make the Docker rules work
 
 http_archive(
@@ -86,7 +84,7 @@ poetry(
     ],
     lockfile = "//test:poetry.lock",
     pyproject = "//test:pyproject.toml",
-    python_interpreter_target = python_interpreter,
+    python_interpreter_target_default = python_interpreter,
 )
 
 poetry(
@@ -97,7 +95,7 @@ poetry(
     ],
     lockfile = "//test/no_group_deps:poetry.lock",
     pyproject = "//test/no_group_deps:pyproject.toml",
-    python_interpreter_target = python_interpreter,
+    python_interpreter_target_default = python_interpreter,
 )
 
 
@@ -116,8 +114,8 @@ container_pull(
     tag = "3.7.4-slim-buster",
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
+# We need skylib to be able to use config_setting_group
+# https://github.com/bazelbuild/bazel-skylib/blob/main/docs/selects_doc.md#selectsconfig_setting_group
 http_archive(
     name = "bazel_skylib",
     sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
@@ -127,11 +125,8 @@ http_archive(
     ],
 )
 
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+# We are testing powerpc and 390x platforms which are only available in newer version of
+# bazels built in platform constraints.
 http_archive(
     name = "platforms",
     urls = [

--- a/rules_poetry/poetry.bzl
+++ b/rules_poetry/poetry.bzl
@@ -9,14 +9,15 @@ POETRY_UNSAFE_PACKAGES = ["setuptools", "distribute", "pip", "wheel"]
 # normally _ would be a delimiter, but these values can include it in the name
 # next would normally be : but bazel uses this in target names
 # so finally we settle on ! for a delimiter in this case.
+# this values from https://peps.python.org/pep-0496/#strings
 SUPPORTED_PLATFORMS = [
     'linux!s390x',
     'linux!ppc64le',
     'linux!aarch64',
     'linux!x86_64',
-    'macos!aarch64',
-    'macos!x86_64',
-    'windows!x86_64'
+    'darwin!aarch64',
+    'darwin!x86_64',
+    'win32!x86_64'
 ]
 
 def _clean_name(name):

--- a/rules_poetry/poetry.bzl
+++ b/rules_poetry/poetry.bzl
@@ -5,6 +5,15 @@
 # See https://github.com/python-poetry/poetry/blob/d2fd581c9a856a5c4e60a25acb95d06d2a963cf2/poetry/puzzle/provider.py#L55
 # and https://github.com/python-poetry/poetry/issues/1584
 POETRY_UNSAFE_PACKAGES = ["setuptools", "distribute", "pip", "wheel"]
+SUPPORTED_PLATFORMS = [
+    'linux!s390x',
+    'linux!ppc64le',
+    'linux!aarch64',
+    'linux!x86_64',
+    'macos!aarch64',
+    'macos!x86_64',
+    'windows!x86_64'
+]
 
 def _clean_name(name):
     return name.lower().replace("-", "_").replace(".", "_")
@@ -21,12 +30,18 @@ def _get_python_interpreter_attr(rctx):
 def _resolve_python_interpreter(rctx):
     python_interpreter = _get_python_interpreter_attr(rctx)
 
-    if rctx.attr.python_interpreter_target:
+    if "win" in rctx.os.name:
+        interpreter_target = rctx.attr.python_interpreter_target_win
+    elif "mac" in rctx.os.name:
+        interpreter_target = rctx.attr.python_interpreter_target_mac
+    else:
+        interpreter_target = rctx.attr.python_interpreter_target
+    
+    if interpreter_target:
         if rctx.attr.python_interpreter:
-            fail("python_interpreter_target and python_interpreter incompatible")
-
-        target = rctx.attr.python_interpreter_target
-        python_interpreter = rctx.path(target)
+            fail("interpreter_target and python_interpreter incompatible")
+    
+        python_interpreter = rctx.path(interpreter_target)
 
         return python_interpreter
 
@@ -79,7 +94,30 @@ def _mapping(repository_ctx):
     return {
         "dependencies": dependencies,
         "groups": groups,
+        "pyproject": pyproject
     }
+
+def extract_markers(repository_ctx, resolved_markers, dep, markers):
+    python_interpreter = _resolve_python_interpreter(repository_ctx)
+
+    if str(type(markers)) == 'list':
+        if dep not in resolved_markers:
+            resolved_markers[dep] = {}
+        for marker in markers:
+            for platform in SUPPORTED_PLATFORMS:
+                system, machine = platform.split('!')
+                test_string = marker['markers'].replace('platform_machine', "'" + machine + "'")
+                test_string = test_string.replace('sys_platform', "'" + system + "'")
+                cmd = [
+                    python_interpreter,
+                    '-c',
+                    'print(' + test_string + ')'
+                ]
+                result = repository_ctx.execute(cmd)
+                if result.stdout.strip() == "True":
+                    if marker['version'] not in resolved_markers[dep]:
+                        resolved_markers[dep][marker['version']] = []
+                    resolved_markers[dep][marker['version']].append(platform)
 
 def _impl(repository_ctx):
     python_interpreter = _resolve_python_interpreter(repository_ctx)
@@ -115,6 +153,13 @@ def _impl(repository_ctx):
         }
     elif "hashes" in metadata:  # Poetry 0.x format
         hashes = ["sha256:" + h for h in metadata["hashes"]]
+    elif metadata["lock-version"] in ["2.0"]:
+        hashes = {}
+        for package in lockfile["package"]:
+            key = package["name"]
+            if key not in hashes:
+                hashes[key] = []
+            hashes[key] += [pack["hash"] for pack in package["files"]]
     else:
         fail("Did not find file hashes in poetry.lock file")
 
@@ -124,7 +169,23 @@ def _impl(repository_ctx):
         if requested.lower() in excludes:
             fail("pyproject.toml dependency {} is also in the excludes list".format(requested))
 
+    toml_markers = {}
+
+    if metadata["lock-version"] in ["2.0"]:
+        poetry_deps = mapping['pyproject']['tool']['poetry']
+        
+        for dep in poetry_deps['dependencies']:
+            extract_markers(repository_ctx, toml_markers, dep, poetry_deps['dependencies'][dep])
+                    
+        if 'group' in poetry_deps:
+            for group in poetry_deps['group']:
+                if 'dependencies' in poetry_deps['group'][group]:
+                    for dep in poetry_deps['group'][group]['dependencies']:
+                        extract_markers(repository_ctx, toml_markers, dep, poetry_deps['group'][group]['dependencies'][dep])
+
+                
     packages = []
+    package_names = []
     for package in lockfile["package"]:
         name = package["name"]
 
@@ -136,10 +197,23 @@ def _impl(repository_ctx):
             print("Skipping " + name)
             continue
 
+        if _clean_name(name) in package_names:
+            continue
+        
+        version_select = '"' + package['version'] + '"'
+        if name in toml_markers:
+            version_select = "select({\n"
+            for version in toml_markers[name]:
+                for platform in toml_markers[name][version]:
+                    system, machine = platform.split('!')
+                    version_select += "        ':{system}!{machine}':'{version}',\n".format(system=system, machine=machine, version=version)
+            version_select += '    })'
+
+        package_names.append(_clean_name(name))
         packages.append(struct(
             name = _clean_name(name),
             pkg = name,
-            version = package["version"],
+            version = version_select,
             hashes = hashes[name],
             marker = package.get("marker", None),
             source_url = package.get("source", {}).get("url", None),
@@ -182,7 +256,7 @@ def dependency(name, group = None):
 download_wheel(
     name = "wheel_{name}",
     pkg = "{pkg}",
-    version = "{version}",
+    version = {version},
     hashes = {hashes},
     marker = "{marker}",
     source_url = "{source_url}",
@@ -210,7 +284,17 @@ py_library(
 load("//:defs.bzl", "download_wheel")
 load("//:defs.bzl", "noop")
 load("//:defs.bzl", "pip_install")
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 """
+    for platform in SUPPORTED_PLATFORMS:
+        system, machine = platform.split('!')
+        build_content += """
+selects.config_setting_group(
+    name = "{platform}",
+    match_all = ["@platforms//os:{system}", "@platforms//cpu:{machine}"],
+)
+""".format(platform=platform, system=system, machine=machine)
 
     install_tags = ["\"{}\"".format(tag) for tag in repository_ctx.attr.tags]
     download_tags = install_tags + ["\"requires-network\""]
@@ -270,6 +354,14 @@ poetry = repository_rule(
             doc = "The command to run the Python interpreter used during repository setup",
         ),
         "python_interpreter_target": attr.label(
+            mandatory = False,
+            doc = "The target of the Python interpreter used during repository setup",
+        ),
+        "python_interpreter_target_win": attr.label(
+            mandatory = False,
+            doc = "The target of the Python interpreter used during repository setup",
+        ),
+        "python_interpreter_target_mac": attr.label(
             mandatory = False,
             doc = "The target of the Python interpreter used during repository setup",
         ),


### PR DESCRIPTION
This PR looks at the version info for each dependency, and if it detects a markers list i.e:
```
networkx: [
     {"version": "1.2.1", "markers": "platform_machine == 's390x'"},
     {"version": "1.2.3", "markers": "platform_machine != 's390x'"},
]
```

Then it will run python locally in the repository context, and will swap in the "platform_machine" or "system_platform" for possible support platforms in a python shell command to test the strings. This is to try to create a select list of possible version to platforms.

This is needed for https://github.com/10gen/mongo/pull/17040 to merge
