### PR TITLE
SERVER-80633 setup a consistent USERPROFILE for windows builds

### DIFF
--- a/rules_poetry/defs.bzl
+++ b/rules_poetry/defs.bzl
@@ -11,6 +11,7 @@ def deterministic_env():
         "PYTHONDONTWRITEBYTECODE": "1",
         "PYTHONHASHSEED": "0",
         "SOURCE_DATE_EPOCH": "315532800",  # set wheel timestamps to 1980-01-01T00:00:00Z
+        "USERPROFILE":".",
     }
 
 def poetry_deps():


### PR DESCRIPTION
On windows, python uses USERPROFILE to expanduser the "~" character: https://docs.python.org/3/library/os.path.html#os.path.expanduser

Some python packages require this to be resolvable. Bazel runs in isolated environments where USERPROFILE is not set. We can set it to a useable deterministic value so python packages and still work. 

This is to fix this kind of error one windows:

```
[2023/11/29 16:24:19.144] ERROR: C:/cygwin/home/mci-exec/_bazel_mci-exec/rhe5vutp/external/poetry/BUILD:3496:15: Collecting pyyaml wheel from pypi failed: (Exit 1): pip.exe failed: error executing command (from target @poetry//:wheel_pyyaml) bazel-out\x64_windows-opt-exec-C0E80C5F\bin\external\pip_archive\pip.exe wheel --quiet --no-deps --use-pep517 --disable-pip-version-check --no-cache-dir --isolated --require-hashes --wheel-dir ... (remaining 3 arguments skipped)
[2023/11/29 16:24:19.144]   error: subprocess-exited-with-error
[2023/11/29 16:24:19.144]   Getting requirements to build wheel did not run successfully.
[2023/11/29 16:24:19.144]   exit code: 1
[2023/11/29 16:24:19.144]   [31 lines of output]
[2023/11/29 16:24:19.144]   Traceback (most recent call last):
[2023/11/29 16:24:19.144]     File "C:\data\mci\d9677c2757b05679569738f670babeb9\tmp\Bazel.runfiles_3gsslphe\runfiles\pip_archive\src\pip\_vendor\pep517\in_process\_in_process.py", line 351, in <module>
[2023/11/29 16:24:19.144]       main()
[2023/11/29 16:24:19.144]     File "C:\data\mci\d9677c2757b05679569738f670babeb9\tmp\Bazel.runfiles_3gsslphe\runfiles\pip_archive\src\pip\_vendor\pep517\in_process\_in_process.py", line 333, in main
[2023/11/29 16:24:19.144]       json_out['return_val'] = hook(**hook_input['kwargs'])
[2023/11/29 16:24:19.144]     File "C:\data\mci\d9677c2757b05679569738f670babeb9\tmp\Bazel.runfiles_3gsslphe\runfiles\pip_archive\src\pip\_vendor\pep517\in_process\_in_process.py", line 118, in get_requires_for_build_wheel
[2023/11/29 16:24:19.144]       return hook(config_settings)
[2023/11/29 16:24:19.144]     File "Z:\data\mci\d9677c2757b05679569738f670babeb9\tmp\pip-build-env-e5xv80e9\overlay\Lib\site-packages\setuptools\build_meta.py", line 325, in get_requires_for_build_wheel
[2023/11/29 16:24:19.144]       return self._get_build_requires(config_settings, requirements=['wheel'])
[2023/11/29 16:24:19.144]     File "Z:\data\mci\d9677c2757b05679569738f670babeb9\tmp\pip-build-env-e5xv80e9\overlay\Lib\site-packages\setuptools\build_meta.py", line 295, in _get_build_requires
[2023/11/29 16:24:19.144]       self.run_setup()
[2023/11/29 16:24:19.144]     File "Z:\data\mci\d9677c2757b05679569738f670babeb9\tmp\pip-build-env-e5xv80e9\overlay\Lib\site-packages\setuptools\build_meta.py", line 480, in run_setup
[2023/11/29 16:24:19.144]       super(_BuildMetaLegacyBackend, self).run_setup(setup_script=setup_script)
[2023/11/29 16:24:19.144]     File "Z:\data\mci\d9677c2757b05679569738f670babeb9\tmp\pip-build-env-e5xv80e9\overlay\Lib\site-packages\setuptools\build_meta.py", line 311, in run_setup
[2023/11/29 16:24:19.144]       exec(code, locals())
[2023/11/29 16:24:19.144]     File "<string>", line 291, in <module>
[2023/11/29 16:24:19.144]     File "Z:\data\mci\d9677c2757b05679569738f670babeb9\tmp\pip-build-env-e5xv80e9\overlay\Lib\site-packages\setuptools\_distutils\core.py", line 159, in setup
[2023/11/29 16:24:19.144]       dist.parse_config_files()
[2023/11/29 16:24:19.144]     File "Z:\data\mci\d9677c2757b05679569738f670babeb9\tmp\pip-build-env-e5xv80e9\overlay\Lib\site-packages\setuptools\dist.py", line 621, in parse_config_files
[2023/11/29 16:24:19.144]       self._parse_config_files(filenames=inifiles)
[2023/11/29 16:24:19.144]     File "Z:\data\mci\d9677c2757b05679569738f670babeb9\tmp\pip-build-env-e5xv80e9\overlay\Lib\site-packages\setuptools\dist.py", line 451, in _parse_config_files
[2023/11/29 16:24:19.144]       filenames = self.find_config_files()
[2023/11/29 16:24:19.144]     File "Z:\data\mci\d9677c2757b05679569738f670babeb9\tmp\pip-build-env-e5xv80e9\overlay\Lib\site-packages\setuptools\_distutils\dist.py", line 338, in find_config_files
[2023/11/29 16:24:19.144]       files = [str(path) for path in self._gen_paths() if os.path.isfile(path)]
[2023/11/29 16:24:19.144]     File "Z:\data\mci\d9677c2757b05679569738f670babeb9\tmp\pip-build-env-e5xv80e9\overlay\Lib\site-packages\setuptools\_distutils\dist.py", line 338, in <listcomp>
[2023/11/29 16:24:19.144]       files = [str(path) for path in self._gen_paths() if os.path.isfile(path)]
[2023/11/29 16:24:19.144]     File "Z:\data\mci\d9677c2757b05679569738f670babeb9\tmp\pip-build-env-e5xv80e9\overlay\Lib\site-packages\setuptools\_distutils\dist.py", line 354, in _gen_paths
[2023/11/29 16:24:19.144]       yield pathlib.Path('~').expanduser() / filename
[2023/11/29 16:24:19.144]     File "C:\data\mci\d9677c2757b05679569738f670babeb9\tmp\Bazel.runfiles_3gsslphe\runfiles\py_windows_x86_64\lib\pathlib.py", line 1440, in expanduser
[2023/11/29 16:24:19.144]       raise RuntimeError("Could not determine home directory.")
[2023/11/29 16:24:19.144]   RuntimeError: Could not determine home directory.
[2023/11/29 16:24:19.144]   [end of output]
```